### PR TITLE
Add configure, make install, manual entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+danebot.1

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,112 @@
+# INSTALL
+
+There is a ./configure script but it takes no arguments.
+It just adjusts the Makefile to install into directories
+that exist on the local system, and to include the installation
+of a systemd service and timer on systems that have systemd,
+or to include the installation of an anacron weekly cronjob
+on other systems (if they have anacron).
+
+The Makefile can instead (or subsequently) be adjusted manually.
+
+The Makefile has several install/uninstall targets:
+
+        The following make targets are available:
+
+          help              - Show this information (default target)
+          check             - Check the local system for prerequisites
+          install           - Same as install-bin + install-cfg + install-man
+          install-bin       - Install /usr/local/bin/danebot
+          install-cfg       - Install /etc/default/danebot
+          install-man       - Install /usr/local/share/man/man1/danebot.1
+          install-systemd   - Install /lib/systemd/system/danebot.service, /lib/systemd/system/danebot.timer
+          install-cronjob   - Install /etc/cron.weekly/danebot
+          uninstall         - Same as uninstall-bin + uninstall-man
+          uninstall-bin     - Uninstall /usr/local/bin/danebot
+          uninstall-cfg     - Uninstall /etc/default/danebot
+          uninstall-man     - Uninstall /usr/local/share/man/man1/danebot.1
+          uninstall-systemd - Uninstall /lib/systemd/system/danebot.service, /lib/systemd/system/danebot.timer
+          uninstall-cronjob - Uninstall /etc/cron.weekly/danebot
+          systemd-enable    - Enable and start the systemd timer
+          systemd-disable   - Disable the systemd timer
+          purge             - Same as uninstall + uninstall-cfg
+          man               - Create ./danebot.1
+          clean             - Delete ./danebot.1
+          ls                - Run ls -l for all installed files
+
+        Before installing, read INSTALL for more details.
+        After installing, read "man danebot" for more details.
+
+To install danebot:
+
+        ./configure
+        make check
+        make install
+
+On systems with systemd, you will also need to enable and start the danebot
+timer. To do this, first stop and disable the certbot timer, if necessary:
+
+        systemctl stop certbot.timer
+        systemctl disable certbot.timer
+
+Then enable and start the danebot timer:
+
+        make systemd-enable
+        # or
+        systemctl enable danebot.time
+        systemctl start danebot.timer
+
+On systems without systemd, but with anacron, "make install" will install
+a weekly cronjob that is automatically enabled.
+
+On systems with neither, you have to install a weekly-ish cronjob manually.
+It should look something like this:
+
+        0 0 * * 0 danebot renew
+
+Danebot can be uninstalled with:
+
+        make uninstall
+
+This will automatically stop and disable the systemd timer, if necessary, or
+remove the anacron weekly cronjob, if necessary, but it won't remove a
+manually added cronjob. You would need to remove it manually as well.
+
+It also won't uninstall the /etc/default/danebot (or similar) configuration
+file, which you might have modified. To do that as well:
+
+        make purge
+
+If you had to manually add a cronjob, you'll have to remove it manually as
+well.
+
+# REQUIREMENTS
+
+Danebot requires the following programs:
+
+        bash, certbot, perl, openssl, rsync, readlink, dirname, basename,
+        find, mktemp, diff, xxd or hexdump
+
+In addition, installing danebot requires:
+
+        make, pod2man
+
+Some of these are standard. Others will need to be installed via
+the local system's package management system if they are not already
+present.
+
+Danebot also requires the following perl modules:
+
+        Net::DNS::Resolver
+        Net::DNS::Packet
+        Net::DNS::Header
+        Net::DNS::RR
+        Net::DNS::RR::TLSA
+
+These can all be installed with:
+
+        cpan Net::DNS
+
+But your local system might have a package for this instead
+(e.g., libnet-dns-perl on Debian).
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,165 @@
+# DANE TLSA-safe certbot wrapper
+
+# Adjust these to suit the local system
+# See ./configure
+
+bindir = /usr/local/bin
+cfgdir = /etc/default
+mandir = /usr/local/share/man
+sysdir = /lib/systemd/system
+crondir = /etc/cron.weekly
+
+mansect = 1
+mansectname = User Commands
+mansectdir = $(mandir)/man$(mansect)
+
+bin = $(bindir)/danebot
+cfg = $(cfgdir)/danebot
+man = $(mansectdir)/danebot.1
+cron = $(crondir)/danebot
+service = $(sysdir)/danebot.service
+timer = $(sysdir)/danebot.timer
+
+#install_extra = install-systemd
+#uninstall_extra = uninstall-systemd
+
+#install_extra = install-cronjob
+#uninstall_extra = uninstall-cronjob
+
+prereqs = bash certbot perl openssl rsync readlink dirname basename find mktemp diff pod2man
+prereqs_oneof = xxd hexdump
+prereqs_perl = Net::DNS::Resolver Net::DNS::Packet Net::DNS::Header Net::DNS::RR Net::DNS::RR::TLSA
+
+help:
+	@echo "The following make targets are available:"
+	@echo ""
+	@echo "  help              - Show this information (default target)"
+	@echo "  check             - Check the local system for prerequisites"
+	@echo "  install           - Same as install-bin + install-cfg + install-man"
+	@echo "  install-bin       - Install $(bin)"
+	@echo "  install-cfg       - Install $(cfg)"
+	@echo "  install-man       - Install $(man)"
+	@echo "  install-systemd   - Install $(service), $(timer)"
+	@echo "  install-cronjob   - Install $(cron)"
+	@echo "  uninstall         - Same as uninstall-bin + uninstall-man"
+	@echo "  uninstall-bin     - Uninstall $(bin)"
+	@echo "  uninstall-cfg     - Uninstall $(cfg)"
+	@echo "  uninstall-man     - Uninstall $(man)"
+	@echo "  uninstall-systemd - Uninstall $(service), $(timer)"
+	@echo "  uninstall-cronjob - Uninstall $(cron)"
+	@echo "  systemd-enable    - Enable and start the systemd timer"
+	@echo "  systemd-disable   - Disable the systemd timer"
+	@echo "  purge             - Same as uninstall + uninstall-cfg"
+	@echo "  man                 Create ./danebot.1"
+	@echo "  clean             - Delete ./danebot.1"
+	@echo "  ls                - Run ls -l for all installed files"
+	@echo
+	@echo 'Before installing, read INSTALL for more details.'
+	@echo 'After installing, read "man danebot" for more details.'
+	@echo
+
+check:
+	@fail=0; \
+	for x in $(prereqs); \
+	do \
+		case "`which $$x 2>&1`" in /*) ;; *) echo "Error: $$x is required but is not installed"; fail=1;; esac; \
+	done; \
+	found=0; \
+	for x in $(prereqs_oneof); \
+	do \
+		case "`which $$x 2>&1`" in /*) found=1;; esac; \
+	done; \
+	if [ $$found = 0 ]; then echo "Error: one of $(prereqs_oneof) is required but neither is installed"; fail=1; fi; \
+	for x in $(prereqs_perl); \
+	do \
+		perldoc $$x >/dev/null 2>&1; \
+		if [ $$? != 0 ]; then echo "Error: Perl module $$x is required but is not installed"; fail=1; fi; \
+	done; \
+	[ $$fail = 0 ] || exit 1
+
+install-bin:
+	@if [ ! -d "$(bindir)" ]; then echo "$(bindir) does not exist (adjust Makefile)"; exit 1; fi
+	cp danebot "$(bin)"
+	chmod 755 "$(bin)"
+
+install-cfg:
+	@if [ ! -d "$(cfgdir)" ]; then echo "$(cfgdir) does not exist (adjust Makefile)"; exit 1; fi
+	@if [ -f "$(cfg)" ]; \
+	then \
+		echo "cp danebot.default $(cfg).dist"; \
+		cp danebot.default "$(cfg).dist"; \
+		chmod 644 "$(cfg).dist"; \
+	else \
+		echo "cp danebot.default $(cfg)"; \
+		cp danebot.default "$(cfg)"; \
+		chmod 644 "$(cfg)"; \
+	fi
+
+install-man: man
+	@if [ ! -d "$(mansectdir)" ]; then echo "$(mansectdir) does not exist (adjust Makefile)"; exit 1; fi
+	cp danebot.1 "$(man)"
+	chmod 644 "$(man)"
+
+man: danebot.1
+
+danebot.1: danebot.1.pod
+	sed 's/C</B</g' $< | pod2man --section='$(mansect)' --center='$(mansectname)' --name=DANEBOT --release=danebot --quotes=none > $@
+
+install: install-bin install-cfg install-man $(install_extra)
+
+uninstall-bin:
+	[ ! -f "$(bin)" ] || rm $(bin)
+
+uninstall-cfg:
+	[ "`echo $(cfg)*`" = "$(cfg)*" ] || rm $(cfg)*
+
+uninstall-man:
+	[ "`echo $(man)*`" = "$(man)*" ] || rm $(man)*
+
+uninstall: uninstall-bin uninstall-man $(uninstall_extra)
+
+purge: uninstall uninstall-cfg
+
+clean:
+	[ ! -f danebot.1 ] || rm danebot.1
+
+install-systemd:
+	@if [ ! -d "$(sysdir)" ]; then echo "$(sysdir) does not exist (adjust Makefile)"; exit 1; fi
+	cp danebot.service danebot.timer "$(sysdir)"
+	chmod 644 "$(service)" "$(timer)"
+	systemctl daemon-reload
+
+uninstall-systemd: systemd-disable
+	[ ! -f "$(service)" ] || rm $(service)
+	[ ! -f "$(timer)" ] || rm $(timer)
+	systemctl daemon-reload
+
+install-cronjob:
+	@if [ ! -d "$(crondir)" ]; then echo "$(crondir) does not exist (adjust Makefile)"; exit 1; fi
+	printf "#!/bin/sh\n\nexec $(bin)\n\n" > "$(cron)"
+	chmod 755 "$(cron)"
+
+uninstall-cronjob:
+	[ ! -f "$(cron)" ] || rm $(cron)
+
+systemd-enable:
+	@if systemctl is-enabled certbot.timer >/dev/null 2>&1; \
+	then \
+		echo "Refusing to enable danebot.timer while certbot.timer is enabled."; \
+		echo "Please execute this then try again:"; \
+		echo; \
+		echo "    systemctl stop certbot.timer"; \
+		echo "    systemctl disable certbot.timer"; \
+		echo; \
+		exit 1; \
+	fi
+	systemctl enable danebot.timer
+	systemctl start danebot.timer
+
+systemd-disable:
+	-systemctl stop danebot.timer
+	-systemctl disable danebot.timer
+
+ls:
+	@ls -l "$(bin)" "$(cfg)"* "$(man)"* "$(service)" "$(timer)" "$(cron)" 2>&-; exit 0
+

--- a/configure
+++ b/configure
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+# DANE TLSA-safe certbot wrapper
+
+# configure - Adjust Makefile to suit the local system
+
+# Check that no arguments were passed (not that kind of ./configure)
+
+if [ $# != 0 ]
+then
+    echo "This configure script doesn't take any arguments" >&2
+    exit 1
+fi
+
+# Some helper functions
+
+enable()
+{
+    macro="$1"
+    target="$2"
+    # Uncomment a target macro in Makefile
+    perl -pi -e "s,^#($macro = $target)$,\1," Makefile
+}
+
+setdir()
+{
+    macro="$1"
+    dir="$2"
+    # Change the value of a directory macro in Makefile
+    perl -pi -e "s,^(\s*$macro\s*=\s*).*$,\1$dir," Makefile
+}
+
+configdir()
+{
+    macro="$1"; shift
+    done=0
+    for dir in "$@"
+    do
+        if [ -d "$dir" ]
+        then
+            setdir "$macro" "$dir"
+            done=1
+            break
+        fi
+    done
+    [ $done = 0 ] && echo "Unknown directory for $macro (Adjust Makefile manually)" >&2
+}
+
+# Set $(bindir), $(cfgdir), $(mandir) - prefer local to system locations
+
+configdir bindir /usr/local/bin /opt/local/bin /usr/pkg/bin /usr/bin
+configdir cfgdir /usr/local/etc /opt/local/etc /usr/pkg/etc /etc/default /etc/defaults
+configdir mandir /usr/local/share/man /usr/local/man /opt/local/share/man /usr/pkg/man /usr/share/man /usr/man
+
+# Include systemd or cron in install/uninstall and set $(crondir)
+
+if [ -d /lib/systemd/system ]
+then
+    enable install_extra install-systemd
+    enable uninstall_extra uninstall-systemd
+else
+    cronned=0
+    for etc in /etc /usr/local/etc /opt/local/etc /usr/pkg/etc
+    do
+        if [ -d $etc/cron.weekly ]
+        then
+            setdir crondir $etc/cron.weekly
+            enable install_extra install-cronjob
+            enable uninstall_extra uninstall-cronjob
+            cronned=1
+            break
+        fi
+    done
+    [ $cronned = 1 ] || echo "Error: No systemd or anacron found (Install cronjob manually)" >&2
+fi
+

--- a/danebot
+++ b/danebot
@@ -56,10 +56,14 @@ TTL=2
 NS=127.0.0.1
 ## --------------
 
-# allow replacement configuration by a user
-if [[ -f /etc/default/danebot ]] ; then
-    . /etc/default/danebot
-fi
+# Allow replacement configuration by a user
+# Choices for Linux/Solaris, FreeBSD/macOS, OpenBSD, NetBSD, macports
+for defaults in /etc/default /etc/defaults /usr/local/etc /usr/pkg/etc /opt/local/etc
+do
+    if [[ -f $defaults/danebot ]] ; then
+        . $defaults/danebot
+    fi
+done
 
 # Avoid charset issues
 export LANG=C LC_ALL=C LC_CTYPE=C IDN_DISABLE=1

--- a/danebot.1.pod
+++ b/danebot.1.pod
@@ -1,0 +1,286 @@
+=head1 NAME
+
+I<danebot> - DANE TLSA-safe certbot wrapper
+
+=head1 SYNOPSIS
+
+ usage: danebot [command] [args...]
+ commands:
+  help                - Show a usage message
+  init [lineage...]   - Convert existing lineages to danebot usage
+  deinit [lineage...] - Restore lineages to certbot control
+  renew               - Renew certificates (weekly)
+  newkey [lineage...] - Rollover the private key(s)
+
+=head1 DESCRIPTION
+
+C<danebot> is a C<certbot> wrapper that helps to avoid SMTP outages
+due to mismatched TLSA records resulting from a Let's Encrypt
+automated certificate renewal.
+
+Specifically, C<danebot> is a shell script that is a small wrapper
+around C<certbot> that:
+
+=over 4
+
+=item 1
+
+Calls C<certbot> as needed to do automated certificate updates, just like
+C<certbot> does.
+
+=item 2
+
+Keeps TLSA records stable by reusing the current public/private key pair for
+certificate renewals rather than creating new keys.
+
+=item 3
+
+Supports key rollover when desired by ensuring that matching TLSA records
+are already published before switching to a new key pair.
+
+=item 4
+
+Supports multiple C<certbot> I<lineages> (renewable certificates -- see the
+[certbot documentation]).
+
+=item 5
+
+Some of the lineages can be simple pass-throughs to C<certbot>.  For these
+lineages, C<danebot> does not manage key rollover to ensure matching TLSA
+records.
+
+=back
+
+L<[certbot documentation]|https://eff-certbot.readthedocs.io/en/stable/what.html>
+
+=head2 Important note:
+
+You B<must> use C<danebot> in place of C<certbot> -- Specifically,
+disable or replace the cron or other process that invokes C<certbot>
+and instead use C<danebot> exclusively.
+
+=head1 USAGE
+
+=head2 Initialization
+
+=over 4
+
+=item 1
+
+Use C<certbot> to create and initialise any certificate I<lineages> you want
+managed on your system.  (Changing the list of DNS names covered by a certificate
+lineage is not yet supported by C<danebot>, you can run C<certbot> interactively to
+do that).
+
+=item 2
+
+Run C<danebot init> so it can find and start managing C<certbot>'s
+certificates.  If you manage more than one certificate I<lineage>,
+you can specify a list of lineage names to convert to C<danebot>.
+
+=back
+
+=head2 Certificate update automation
+
+Pick whether you want to call C<danebot> from systemd or cron.  Either
+way, make sure you disable any C<certbot renew> cron or other scripts.
+
+=head3 Using systemd integration
+
+For C<systemd>, install C<danebot.service> and C<danebot.timer> in
+C</lib/systemd/system/> with C<make install-systemd>, and enable them.
+
+=head3 Using cron
+
+=over 4
+
+=item 1
+
+Run C<danebot renew> in a weekly-ish cron job.  It will continue to
+reuse your existing private key for your certificates (see
+below for rolling your keys).
+   
+=item 2
+
+While C<certbot> hooks are already non-reliable (don't retry later
+on failure to complete, ...), they're even more so a poor fit with
+C<danebot>, because when managed by C<danebot>, C<certbot> only puts the new
+certificate in a staging directory, which is post-processed by C<danebot>.
+
+When C<certbot> hooks run, the new certificate chain is not yet deployed.
+Therefore, you'll need to run additional commands after C<danebot> is done,
+that check for recent changes in the "live" certificate files, and
+take appropriate actions.
+
+=back
+
+=head2 Rolling your private key to a new key using danebot
+
+To have C<danebot> start the process of rolling a given I<lineage> to a new
+private PKIX key:
+ 
+=over 4
+
+=item 1
+
+Create a C<dane-ee> file in the C</etc/letsencrypt/staging/>I<lineage> directory.
+This file must list one line per monitored TLSA record set.  Each line has
+two fields, a DANE matching type and a DNS FQDN where the TLSA record is
+expected to be found.  Example:
+
+ 1 _25._tcp.smtp.acme.example
+
+With this setting, new keys will only be used once a matching C<S<3 1 1>>
+TLSA record is published for C<_25._tcp.smtp.acme.example>.  If your
+certificate covers multiple logical MTA names, add a line(s) for each.  A
+recommended best practice is to use a single MX hostname for multiple
+domains to keep the TLSA count low, rather than creating a separate I<MX>
+name for each domain.
+
+You can also require that the Let's Encrypt issued certificate have a set of
+expected DNS names by creating a C<dnsnames> file in the same
+I<lineage>-specific C<staging> directory.  List one DNS name per line.  New
+certificates will only be made "live" when all the required names are present.
+
+=item 2
+
+Run C<danebot newkey> I<lineage> by hand.  You must specify exactly one
+I<lineage> name.  This will create the new key but will not start using it
+yet.  Instead, it will output a new C<TLSA> record that you should B<add> to
+(not replace) all the associated C<_port._tcp.server.example> DNS RRsets
+(typically just one when the certificate covers just one hostname).  B<Do
+not remove the TLSA records matching the original key just yet, as the
+certificate is still using the old key.>
+
+=item 3
+
+Continue running the C<danebot renew> cron job as before.  C<danebot> will
+monitor for the appearance of the expected C<TLSA> records and wait at
+least 2 more days before calling C<certbot> to switch to using the new key
+for creating certificates.
+
+=item 4
+
+After C<danebot> switches to the new key, you can remove the older TLSA
+records from DNS (making sure to remove the old and not the new ones).
+
+=back
+
+=head1 HOW IT WORKS
+
+Under the hood, C<danebot> creates lineage-specific C<staging> sub-directories
+named C</etc/letsencrypt/staging/>I<lineage-name>.  Certificates and keys
+generated by C<certbot> are only copied to the C<live> directory after basic
+validation.
+
+An extra feature of C<danebot>: for applications that support atomically
+loading both the private key and the certificate chain from the same
+file, C<danebot> also atomically updates a C<combo.pem> file in the
+lineage-specific C<live> directory.  The C<combo.pem> file will contain
+the private key followed by the certificate chain with the leaf
+certificate before the rest of the chain.  If you decide to disable
+C<danebot> and go back to C<certbot>, don't forget to go back to using
+C<privkey.pem> and C<fullchain.pem>, as C<certbot> will not update
+C<combo.pem>.
+
+By default C<danebot> keeps the underlying public/private key pair fixed
+across certificate updates, allowing the extant TLSA records, either or
+both of:
+
+=over 4
+
+=item * 3 1 1: i.e. C<DANE-EE(3) SPKI(1) SHA2-256(1)> _sha256(pubkey)_
+
+=item * 3 1 2: i.e. C<DANE-EE(3) SPKI(1) SHA2-512(2)> _sha512(pubkey)_
+
+=back
+
+to remain unchanged across the certificate update.  However, at your discretion,
+C<danebot> also supports worry-free key rollover (as explained above).  You can
+stage a _next_ key that will only replace the _current_ key once the
+appropriate additional TLSA records have been in place long enough for stale
+cached copies of the TLSA records to have expired.  Once the new TLSA records
+have been published for the minimum time, a new certificate chain is obtained
+with the staged _next_ as the new _current_ key.
+
+B<NOTE>: The safety-net is only in place if you create a C<dane-ee> file in the
+lineage-specific C<staging> directory with the expected TLSA record matching
+type(s) and DNS locations.  Otherwise the new key will be used on the next
+renew cycle even if no matching TLSA records have been published.
+
+=head1 FILES
+
+=head2 C</etc/default/danebot>
+
+This configuration file is for overriding some default environment variables
+used by danebot. It's a bash script. The directory varies on different
+operating systems. This file can be in /etc/default, /etc/defaults,
+/usr/local/etc, /usr/pkg/etc, or /opt/local/etc.
+
+=head3 Setting KEYALG and KEYOPTS
+
+For default key rollover parameters, these defaults may be changed in
+C</etc/default/danebot>, example content:
+
+ KEYALG="rsa"
+ # KEYOPTS is an array of "-pkeyopt" option values applicable with the
+ # $KEYALG algorithm.  See the OpenSSL genpkey(1) manpage for details.
+ KEYOPTS=(rsa_keygen_bits:2048)
+
+L<[OpenSSL 1.1.1]|https://www.openssl.org/docs/man1.1.1/man1/genpkey.html>
+
+L<[OpenSSL 3.0]|https://www.openssl.org/docs/man3.0/man1/genpkey.html>
+
+=head3 Specifying the TTL
+
+ # Minimum time to wait before assuming that fresh TLSA RRs are globally visible
+ # (expired from all remote caches, and updated on all secondary nameservers).
+ #
+ # This value is passed to find(1) as a "-mtime" option.  The default unit is
+ # days.  The FreeBSD version of find(1) supports explicit units ([smhdw]).
+
+ TTL=2
+
+=head3 Specifying a validating resolver
+
+Specify the IP address of (an ideally local) trusted validating DNS
+resolver:
+
+ NS=127.0.0.1
+
+This is used to check the presence of required TLSA records.  Best to avoid
+remote DNS servers (e.g. the various public DNS services), since the network
+path to these servers is likely insecure.
+
+=head2 C</etc/letsencrypt/staging/*/dane-ee>
+
+This file must list one line per monitored TLSA record set.  Each line has
+two fields, a DANE matching type and a DNS FQDN where the TLSA record is
+expected to be found.  Example:
+
+ 1 _25._tcp.smtp.acme.example
+
+On some operating systems, this is under /usr/local/etc/letsencrypt.
+See above for more details.
+
+=head2 C</etc/letsencrypt/staging/*/dnsnames>
+
+You can require that the Let's Encrypt issued certificate have a set of
+expected DNS names with this file. List one DNS name per line.
+
+On some operating systems, this is under /usr/local/etc/letsencrypt.
+See above for more details.
+
+=head1 SEE ALSO
+
+L<certbot(1)>, L<openssl(1)>.
+
+=head1 AUTHOR
+
+Copyright (C) 2022 Viktor Dukhovni <ietf-dane@dukhovni.org>
+
+=head1 URL
+
+L<[danebot]|https://github.com/tlsaware/danebot>
+
+=cut 

--- a/danebot.default
+++ b/danebot.default
@@ -1,0 +1,33 @@
+# /etc/default/danebot - DANE TLSA-safe certbot wrapper
+# This is bash source.
+
+# Key rollover parameters
+
+KEYALG="rsa"
+# KEYOPTS is an array of "-pkeyopt" option values applicable with the
+# $KEYALG algorithm.  See the OpenSSL genpkey(1) manpage for details.
+KEYOPTS=(rsa_keygen_bits:2048)
+
+# [OpenSSL 1.1.1](https://www.openssl.org/docs/man1.1.1/man1/genpkey.html)
+# [OpenSSL 3.0](https://www.openssl.org/docs/man3.0/man1/genpkey.html)
+
+# Minimum time to wait before assuming that fresh TLSA RRs are globally visible
+# (expired from all remote caches, and updated on all secondary nameservers).
+#
+# This value is passed to find(1) as a "-mtime" option.  The default unit is
+# days.  The FreeBSD version of find(1) supports explicit units ([smhdw]).
+
+TTL=2
+
+# If the system default OpenSSL CAfile does not include the root CA that issued
+# the LE intermediate CA cert, then you'll need to set the "SSL_CERT_FILE"
+# environment variable to the name of a file with the required root CA certs.
+
+# export SSL_CERT_FILE=/some/where.pem
+
+# IP address of trusted validating DNS resolver, should not be "too" remote!
+# Needed to check TLSA record presence.  Ideally loopback.  Should we just
+# always use /etc/resolv.conf, even if a distant public server?
+
+NS=127.0.0.1
+


### PR DESCRIPTION
Hi, This is just some admin work that should hopefully make it a little easier for people to start using danebot.

There's a Makefile to check for prerequisites (`make check`), and to install danebot (`make install`).

There's a ./configure script to adapt the Makefile to the local system. It checks for install directories used by Linux, FreeBSD, OpenBSD, NetBSD, macOS/macports, and Solaris. And it includes the installation of the systemd service and timer on systems that have systemd, or it includes the installation of an anacron /etc/cron.weekly script on systems that have anacron (although that might just be Linux, not sure).

There's a manual entry which is just most of the README converted to manpage conventions (POD syntax).

And an /etc/default/danebot file (or similar) with defaults and documentation copied from the code.

And an INSTALL file to explain how to install and show the commands needed to do so.

It adds a .gitignore file to ignore the generated danebot.1 installable manpage.

It does change danebot itself, but only to put the reading of the defaults config file into a loop over a list of directories so as to adapt to different operating system preferences.