### PR TITLE
Makefile: FIX Perl checks by checking for module, not help file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ check:
 		if [ $$? != 0 ]; then echo "Error: Perl module $$x is required but is not installed"; fail=1; fi; \
 	done; \
 	[ $$fail = 0 ] || exit 1
-	[ $$fail = 0 ] || exit 1
 
 install-bin:
 	@if [ ! -d "$(bindir)" ]; then echo "$(bindir) does not exist (adjust Makefile)"; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,10 @@ check:
 	if [ $$found = 0 ]; then echo "Error: one of $(prereqs_oneof) is required but neither is installed"; fail=1; fi; \
 	for x in $(prereqs_perl); \
 	do \
-		perldoc $$x >/dev/null 2>&1; \
+		perl -M$$x -e1 >/dev/null 2>&1; \
 		if [ $$? != 0 ]; then echo "Error: Perl module $$x is required but is not installed"; fail=1; fi; \
 	done; \
+	[ $$fail = 0 ] || exit 1
 	[ $$fail = 0 ] || exit 1
 
 install-bin:

--- a/danebot
+++ b/danebot
@@ -32,10 +32,6 @@ fi
 # Log file location
 LOGFILE="/var/log/danebot.log"
 
-# Key rollover parameters
-KEYALG="rsa"
-KEYOPTS=(rsa_keygen_bits:2048)
-
 # ADVANCED: The file permissions of the "combo.pem" chain + key file.
 # When in doubt, leave the default in place.
 #
@@ -117,6 +113,53 @@ export LANG=C LC_ALL=C LC_CTYPE=C IDN_DISABLE=1
 checkpipe() {
     set -- "${PIPESTATUS[@]}"
     local ec; for ec; do if [[ "$ec" != 0 ]]; then return 1; fi; done
+}
+
+# Detect per-lineage KEYALG and KEYOPTS from renewal config
+detect_keyalg() {
+    local lineage="$1"
+    local conf="renewal/${lineage}.conf"
+    local default_rsa_size=2048
+    local default_ecdsa_curve="prime256v1"
+
+    if [[ ! -f "$conf" ]]; then
+        log_error "Renewal config '$conf' not found for lineage '$lineage'"
+        return 1
+    fi
+
+    # Initialise/Reset variables
+    KEYALG=""
+    KEYOPTS=()
+
+    # Extract key_type from renewal config
+    local key_type key_curve key_rsa
+    key_type=$(awk -F= '/^\s*key_type\s*=/ {gsub(/ /,"",$2); print $2}' "$conf" | tr '[:upper:]' '[:lower:]')
+
+    if [[ "$key_type" == "ecdsa" ]]; then
+        # Extract curve if present
+        key_curve=$(awk -F= '/^\s*ec_curve\s*=/ {gsub(/ /,"",$2); print $2}' "$conf")
+        KEYALG="ecdsa"
+        KEYOPTS=("ec_paramgen_curve:${key_curve:-$default_ecdsa_curve}")
+        if [[ -z "$key_curve" ]]; then
+            log_warn "No ec_curve specified in $conf, falling back to default $default_ecdsa_curve for lineage '$lineage'"
+        fi
+    elif [[ "$key_type" == "rsa" || -z "$key_type" ]]; then
+        # Extract RSA size if present
+        key_rsa=$(awk -F= '/^\s*rsa_key_size\s*=/ {gsub(/ /,"",$2); print $2}' "$conf")
+        KEYALG="rsa"
+        KEYOPTS=("rsa_keygen_bits:${key_rsa:-$default_rsa_size}")
+        if [[ -z "$key_rsa" ]]; then
+            if [[ -z "$key_type" ]]; then
+                log_warn "No key_type specified in $conf, assuming default RSA for lineage '$lineage'"
+            fi
+            log_warn "No rsa_key_size specified in $conf, falling back to default $default_rsa_size for lineage '$lineage'"
+        fi
+    else
+        log_error "Unsupported key_type '$key_type' in $conf for lineage '$lineage'"
+        return 1
+    fi
+
+    log_info "Lineage '$lineage': using KEYALG=$KEYALG, KEYOPTS=${KEYOPTS[*]}"
 }
 
 # Extract various details from a PEM file.

--- a/danebot
+++ b/danebot
@@ -29,6 +29,9 @@ fi
 # CONFIGURATION section
 # These parameters can be overridden by placing new values in /etc/default/danebot
 
+# Log file location
+LOGFILE="/var/log/danebot.log"
+
 # Key rollover parameters
 KEYALG="rsa"
 KEYOPTS=(rsa_keygen_bits:2048)
@@ -71,6 +74,33 @@ TTL=2
 #
 NS=127.0.0.1
 ## --------------
+
+# Logging function
+# Generic logging function
+log() {
+    local level="$1"
+    local msg="$2"
+    local timestamp
+    timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+
+    # Print to screen
+    case "$level" in
+        INFO)  echo "[$timestamp] [$level] $msg" ;;
+        WARN|ERROR) echo "[$timestamp] [$level] $msg" >&2 ;;
+        *) echo "[$timestamp] [UNKNOWN] $msg" >&2 ;;
+    esac
+
+    # Ensure log directory exists
+    mkdir -p "$(dirname "$LOGFILE")" 2>/dev/null || :
+
+    # Append to logfile, do not fail if logfile cannot be written
+    printf "[%s] [%s] %s\n" "$timestamp" "$level" "$msg" >> "$LOGFILE" 2>/dev/null
+}
+
+# Convenience wrappers
+log_info()  { log "INFO" "$1"; }
+log_warn()  { log "WARN" "$1"; }
+log_error() { log "ERROR" "$1"; }
 
 # Allow replacement configuration by a user
 # Choices for Linux/Solaris, FreeBSD/macOS, OpenBSD, NetBSD, macports


### PR DESCRIPTION
On Debian 13 with `libnet-dns-perl` the command `make check` failed as the perl docs are not found/installed.

This change tests for the actual modules.