### PR TITLE
Implement key algorithm detection in danebot, to replace setting it for all keys.

### DIFF
--- a/danebot
+++ b/danebot
@@ -94,8 +94,8 @@ detect_keyalg() {
     local default_ecdsa_curve="prime256v1"
 
     if [[ ! -f "$conf" ]]; then
-        printf "Renewal config '$conf' not found for lineage '$lineage'"
-        exit 2
+        printf "ERROR: Renewal config '$conf' not found for lineage '$lineage'"
+        exit 1
     fi
 
     # Initialise/Reset variables
@@ -112,7 +112,7 @@ detect_keyalg() {
         KEYALG="ecdsa"
         KEYOPTS=("ec_paramgen_curve:${key_curve:-$default_ecdsa_curve}")
         if [[ -z "$key_curve" ]]; then
-            printf "No ec_curve specified in $conf, falling back to default $default_ecdsa_curve for lineage '$lineage'"
+            printf "Warning: No ec_curve specified in $conf, falling back to default $default_ecdsa_curve for lineage '$lineage'"
         fi
     elif [[ "$key_type" == "rsa" || -z "$key_type" ]]; then
         # Extract RSA size if present
@@ -121,13 +121,13 @@ detect_keyalg() {
         KEYOPTS=("rsa_keygen_bits:${key_rsa:-$default_rsa_size}")
         if [[ -z "$key_rsa" ]]; then
             if [[ -z "$key_type" ]]; then
-                printf "No key_type specified in $conf, assuming default RSA for lineage '$lineage'"
+                printf "Warning: No key_type specified in $conf, assuming default RSA for lineage '$lineage'"
             fi
-            printf "No rsa_key_size specified in $conf, falling back to default $default_rsa_size for lineage '$lineage'"
+            printf "Warning: No rsa_key_size specified in $conf, falling back to default $default_rsa_size for lineage '$lineage'"
         fi
     else
-        printf "Unsupported key_type '$key_type' in $conf for lineage '$lineage'"
-        return 1
+        printf "ERROR: Unsupported key_type '$key_type' in $conf for lineage '$lineage'"
+        exit 1
     fi
 
     printf "Lineage '$lineage': using KEYALG=$KEYALG, KEYOPTS=${KEYOPTS[*]}"

--- a/danebot
+++ b/danebot
@@ -29,10 +29,6 @@ fi
 # CONFIGURATION section
 # These parameters can be overridden by placing new values in /etc/default/danebot
 
-# Key rollover parameters
-KEYALG="rsa"
-KEYOPTS=(rsa_keygen_bits:2048)
-
 # ADVANCED: The file permissions of the "combo.pem" chain + key file.
 # When in doubt, leave the default in place.
 #
@@ -87,6 +83,54 @@ export LANG=C LC_ALL=C LC_CTYPE=C IDN_DISABLE=1
 checkpipe() {
     set -- "${PIPESTATUS[@]}"
     local ec; for ec; do if [[ "$ec" != 0 ]]; then return 1; fi; done
+}
+
+# Detect per-lineage KEYALG and KEYOPTS from renewal config
+
+detect_keyalg() {
+    local lineage="$1"
+    local conf="renewal/${lineage}.conf"
+    local default_rsa_size=2048
+    local default_ecdsa_curve="prime256v1"
+
+    if [[ ! -f "$conf" ]]; then
+        printf "Renewal config '$conf' not found for lineage '$lineage'"
+        exit 2
+    fi
+
+    # Initialise/Reset variables
+    KEYALG=""
+    KEYOPTS=()
+
+    # Extract key_type from renewal config
+    local key_type key_curve key_rsa
+    key_type=$(awk -F= '/^\s*key_type\s*=/ {gsub(/ /,"",$2); print $2}' "$conf" | tr '[:upper:]' '[:lower:]')
+
+    if [[ "$key_type" == "ecdsa" ]]; then
+        # Extract curve if present
+        key_curve=$(awk -F= '/^\s*ec_curve\s*=/ {gsub(/ /,"",$2); print $2}' "$conf")
+        KEYALG="ecdsa"
+        KEYOPTS=("ec_paramgen_curve:${key_curve:-$default_ecdsa_curve}")
+        if [[ -z "$key_curve" ]]; then
+            printf "No ec_curve specified in $conf, falling back to default $default_ecdsa_curve for lineage '$lineage'"
+        fi
+    elif [[ "$key_type" == "rsa" || -z "$key_type" ]]; then
+        # Extract RSA size if present
+        key_rsa=$(awk -F= '/^\s*rsa_key_size\s*=/ {gsub(/ /,"",$2); print $2}' "$conf")
+        KEYALG="rsa"
+        KEYOPTS=("rsa_keygen_bits:${key_rsa:-$default_rsa_size}")
+        if [[ -z "$key_rsa" ]]; then
+            if [[ -z "$key_type" ]]; then
+                printf "No key_type specified in $conf, assuming default RSA for lineage '$lineage'"
+            fi
+            printf "No rsa_key_size specified in $conf, falling back to default $default_rsa_size for lineage '$lineage'"
+        fi
+    else
+        printf "Unsupported key_type '$key_type' in $conf for lineage '$lineage'"
+        return 1
+    fi
+
+    printf "Lineage '$lineage': using KEYALG=$KEYALG, KEYOPTS=${KEYOPTS[*]}"
 }
 
 # Extract various details from a PEM file.


### PR DESCRIPTION
### Added key algorithm detection for renewal configuration.

This change removes the original setting of a default key type and key size, which forced the user to set environment variables before some invocations where key types and/or sizes/curves are different from that default setting (e.g. one RSA and one ECDSA cert).

The new function retrieves the key type and - if available - key size / curve from certbot's renewal configuration file.

In case the size or curve are missing, a warning is printed, and certbot's default settings (for RSA: 2048, for ECDSA: 256) are used as a fallback.

In case a really old version of certbot is used (certbot < 1.xx; e.g. on CentOS 7, Debian 10, Ubuntu 18.04), where only RSA is available, and therefore no key type was specified, the fallback is RSA 2048 (certbot's defaults at that time).